### PR TITLE
Refactors and fixes sample entropy (last M values must be ignored)

### DIFF
--- a/MultiscaleEntropy/mse.py
+++ b/MultiscaleEntropy/mse.py
@@ -87,6 +87,7 @@ def sample_entropy(x, m=[2], r=[0.15], sd=None, return_type='dict', safe_mode=Fa
             tmp_m.append(mm)
             tmp_m.append(mm+1)
         tmp_m = list(set(tmp_m))
+        max_m = max(tmp_m)
         for mm in tmp_m:
             count[mm] = 0
 
@@ -109,13 +110,15 @@ def sample_entropy(x, m=[2], r=[0.15], sd=None, return_type='dict', safe_mode=Fa
                 yield (end - run_length, run_length)
 
         # j = offset of template vector B w.r.t. template vector A
-        for j in range(1, len(x)-min(m)+1):
+        for j in range(1, len(x)-max_m+1):
             for start, length in similar_runs(x, j, len(x) - j, threshold):
                 # how many vectors of length max_m fit between start of run
                 # and end of data?
+                max_count = len(x) - (start + j + max_m - 1)
                 for mm in tmp_m:
                     # how many vectors of length mm fit within the run?
                     count_mm = length - mm + 1
+                    count_mm = min(count_mm, max_count)
                     count[mm] += max(0, count_mm)
         for mm in m:
             if count[mm+1] == 0 or count[mm] == 0:


### PR DESCRIPTION

@DominiqueMakowski called my attention to a discrepancy between this implementation of the sample entropy and my implementation in [nolds](https://github.com/CSchoel/nolds) in this issue: https://github.com/neuropsychology/NeuroKit/issues/75 .

I think there is a small issue in MultiscaleEntropy that causes this inconsistence: The sample entropy is the conditional probability that two pieces of the input sequence that are similar for M time steps will remain similar for M+1 time steps. If we count the number of similar template vector pairs of length M we therefore must ignore the last template vector, since it cannot be followed for another time step. If we would include it in the calculation, this would introduce a bias that underestimates the number of template vectors that remain similar for a length of M+1.

Reference: [Richman and Moorman (2000)](https://doi.org/10.1152/ajpheart.2000.278.6.H2039), page H2042

At Dominique's hint I found similar issues with entro-py ([ixjlyons/entro-py#2](https://github.com/ixjlyons/entro-py/pull/2)), pyeeg ([forrestbao/pyeeg#29](https://github.com/forrestbao/pyeeg/pull/29)) and pyEntropy (https://github.com/nikdon/pyEntropy/pull/15). With the suggested fix in this pull request, MultiscaleEntropy produces the same output as [nolds](https://github.com/CSchoel/nolds) and the R-package [pracma](https://github.com/cran/pracma/blob/master/R/entropy.R) (which I used as reference for the implementation of nolds), as well as the fixed versions of pyeeg, entro-py and pyEntropy,

```python
import nolds
import entropy as e
import pyentrp.entropy as pent
import pyeeg.entropy as peeg
import numpy as np
import MultiscaleEntropy as mse

num = 100
dim = 2
tol = 0.2
signal = np.cos(np.linspace(start=0, stop=30, num=num))
print("entro-py", e.sampen(signal, dim, tol, False))
print(" pyentrp", pent.sample_entropy(signal, dim + 1, tol)[-1])
print("   pyeeg", peeg.samp_entropy(signal, dim, tol))
print(" MSEntr.", mse.sample_entropy(signal, [dim], [tol], sd=1, return_type="list")[0][0])
print("   nolds", nolds.sampen(signal, emb_dim=dim, tolerance=tol))
```

```
entro-py 0.27672305866206137
 pyentrp 0.2767230586620615
   pyeeg 0.27672305866206137
 MSEntr. 0.2767230586620615
   nolds 0.2767230586620615
```

Since I found the code in MultiscaleEntropy hard to understand, I took the liberty to refactor it. After I was done with that I could also identify the actual culprit in the original code. So if you would like to incorporate the fix but not my refactored version, you can alternatively pull the branch [bugfix](https://github.com/CSchoel/MultiscaleEntropy/tree/bugfix) in my fork.

